### PR TITLE
feat: Optimize game list page performance and clarity

### DIFF
--- a/src/app/game-lists/actions.ts
+++ b/src/app/game-lists/actions.ts
@@ -1,20 +1,34 @@
 'use server'
+// Import unstable_cache from next/cache for caching functionality
+import { unstable_cache } from "next/cache";
 import { IGameListResponse } from "@/types";
 import axios from "axios";
 import { cookies } from "next/headers";
 import { decrypt } from "../action";
 import { STEAM_ID_COOKIE } from "../lib/constant";
 
-export const fetchGameLists = async() => {
+export const fetchGameLists = async () => {
     const cookiesStore = await cookies();
     const steamIdCookies = cookiesStore.get(STEAM_ID_COOKIE);
     let steamIdKey;
-    if(steamIdCookies) {
+
+    if (steamIdCookies) {
         const id = await decrypt(steamIdCookies?.value);
         steamIdKey = id?.steamId
     } else {
         steamIdKey = process.env.MY_ID
     }
-    const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_API_URL}/IPlayerService/GetOwnedGames/v0001/?key=${process.env.STEAM_KEY}&steamid=${steamIdKey}&include_appinfo=true&include_played_free_games=true`);
-    return response.data.response as IGameListResponse
+
+    // Wrap the data fetching logic with unstable_cache
+    // The cache key is an array including a unique string 'game-lists' and the steamIdKey
+    // This ensures that the data is cached per user
+    // The revalidate option is set to 3600 seconds (1 hour)
+    return unstable_cache(
+        async () => {
+            const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_API_URL}/IPlayerService/GetOwnedGames/v0001/?key=${process.env.STEAM_KEY}&steamid=${steamIdKey}&include_appinfo=true&include_played_free_games=true`);
+            return response.data.response as IGameListResponse;
+        },
+        ['game-lists', steamIdKey], // Cache key: unique string and steamIdKey
+        { revalidate: 3600 } // Revalidate every 1 hour
+    )();
 }

--- a/src/app/game-lists/page.tsx
+++ b/src/app/game-lists/page.tsx
@@ -9,8 +9,8 @@ import { Suspense } from 'react';
 
 const GameLists = async ({ searchParams }: { searchParams: Promise<{sort: string, search : string}>}) => {
   const gameLists = await fetchGameLists();
-  let game_count = 0
   let { games } = gameLists;
+  const totalApiGameCount = gameLists.game_count; // Total games from API
   const ALLMINUTESPLAYTIME = games.map(item => item.playtime_forever).reduce((a, b) => a + b, 0);
 
   const resolvedSearchParams = await Promise.resolve(searchParams);
@@ -27,7 +27,7 @@ const GameLists = async ({ searchParams }: { searchParams: Promise<{sort: string
   }
 
   games = filteredGames;
-  game_count = games.length;
+  const displayedGameCount = games.length; // Count of games after filtering
 
 
   if (sortBy === 'playtime_desc') {
@@ -45,7 +45,12 @@ const GameLists = async ({ searchParams }: { searchParams: Promise<{sort: string
         </h1>
         <p className="text-lg sm:text-xl text-gray-300 mb-2">
           Total games in your collection:{" "}
-          <span className="font-semibold text-white">{game_count}</span>
+          <span className="font-semibold text-white">{totalApiGameCount}</span>
+        </p>
+        <p className="text-base sm:text-lg text-gray-400 mb-6">
+          Displaying:{" "}
+          <span className="font-semibold text-white">{displayedGameCount}</span>
+          {searchQuery && ` (filtered by "${searchQuery}")`}
         </p>
         <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-red-400 leading-relaxed">
           TOTAL PLAYTIME:{" "}


### PR DESCRIPTION
- Implemented server-side caching for `fetchGameLists` using Next.js `unstable_cache`. This caches the response from the Steam API for 1 hour per user, significantly reducing load times for subsequent visits and when applying filters/sorts.
- Refined game count display on the game list page:
    - Shows the total number of games available from the API.
    - Shows the number of games currently displayed after filtering.
- Removed redundant variable initialization for game count.
- Added comments to `actions.ts` explaining the caching strategy.

These changes address the reported slowness of the game list page by reducing redundant API calls and improving data handling clarity.